### PR TITLE
fftools/cmdutils: Inline print_error()

### DIFF
--- a/fftools/cmdutils.c
+++ b/fftools/cmdutils.c
@@ -895,11 +895,6 @@ do {                                                                           \
     return 0;
 }
 
-void print_error(const char *filename, int err)
-{
-    av_log(NULL, AV_LOG_ERROR, "%s: %s\n", filename, av_err2str(err));
-}
-
 int read_yesno(void)
 {
     int c = getchar();

--- a/fftools/cmdutils.h
+++ b/fftools/cmdutils.h
@@ -395,7 +395,10 @@ int setup_find_stream_info_opts(AVFormatContext *s,
  *
  * @see av_strerror()
  */
-void print_error(const char *filename, int err);
+static inline void print_error(const char *filename, int err)
+{
+    av_log(NULL, AV_LOG_ERROR, "%s: %s\n", filename, av_err2str(err));
+}
 
 /**
  * Print the program banner to stderr. The banner contents depend on the


### PR DESCRIPTION
It is only used by ffprobe (once) and ffplay (twice); inlining it avoids including it unnecessarily into ffmpeg.

Reviewed-by: Stefano Sabatini <stefasab@gmail.com>