### PR TITLE
avcodec/mediacodecenc: Flush bsf after create extradata

### DIFF
--- a/libavcodec/mediacodecenc.c
+++ b/libavcodec/mediacodecenc.c
@@ -681,6 +681,7 @@ bailout:
         s->eof_sent = 0;
         ff_AMediaCodec_flush(s->codec);
     }
+    av_bsf_flush(s->bsf);
     av_packet_free(&pkt);
     return ret;
 }


### PR DESCRIPTION
Avoid leaving any data inside bsf while also avoid keep bsf in EOF state.