### PR TITLE
configure: Only try to use the -no_warn_duplicate_libraries flag on D…

### DIFF
--- a/configure
+++ b/configure
@@ -6478,7 +6478,9 @@ check_cc intrinsics_sse2 emmintrin.h "__m128i test = _mm_setzero_si128()"
 
 check_ldflags -Wl,--as-needed
 check_ldflags -Wl,-z,noexecstack
-check_ldflags -Wl,-no_warn_duplicate_libraries
+if [ $target_os = "darwin" ]; then
+    check_ldflags -Wl,-no_warn_duplicate_libraries
+fi
 
 if ! disabled network; then
     check_func getaddrinfo $network_extralibs


### PR DESCRIPTION
…arwin

While we only add the flag if the linker seems to support it, it turns out that ld.bfd had a bug where the flag is accidentally accepted, and the flag produces an output file named "_warn_duplicate_libraries".

The ld.bfd bug was fixed in binutils 2.36, in
https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=3991c7acb29aa8d7d52150695eb3efa03a08dd50.