### PR TITLE
avcodec/vvc/thread: Check frame to be non NULL

### DIFF
--- a/libavcodec/vvc/dec.c
+++ b/libavcodec/vvc/dec.c
@@ -996,7 +996,7 @@ static int vvc_decode_frame(AVCodecContext *avctx, AVFrame *output,
     if (ret < 0)
         return ret;
 
-    if (!fc->ft)
+    if (!fc->ft || !fc->ref)
         return avpkt->size;
 
     ret = submit_frame(s, fc, output, got_output);


### PR DESCRIPTION
Fixes: NULL pointer dereference
Fixes: 71303/clusterfuzz-testcase-minimized-ffmpeg_AV_CODEC_ID_VVC_fuzzer-4875859050168320

Found-by: continuous fuzzing process https://github.com/google/oss-fuzz/tree/master/projects/ffmpeg
Reported-by: Michael Niedermayer <michael@niedermayer.cc>